### PR TITLE
add frontmatter to provide metadata to devhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+---
+description: Migrate from Aporeto Network Security Policy to Openshifts' implementation of Kubernetes Network Policy
+resourceType: Documentation
+title: Networkpolicy Migration Workshop
+---
+
 # TL;DR
 
 You're going to migrate from Aporeto Network Security Policy (NSP) to OpenShift's implementation of Kubernetes Network Policy (KNP) by first adding NSP to your namespace(s) to open up network communication so all pods can talk to all other pods within a given namespace. Then, you'll create new KNP to ratchet down communications to a sane level.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate from Aporeto Network Security Policy to Openshifts' implementation of Kubernetes Network Policy
+description: Migrate from Aporeto Network Security Policy to Openshift's implementation of Kubernetes Network Policy
 resourceType: Documentation
 title: Networkpolicy Migration Workshop
 ---


### PR DESCRIPTION
## Summary
To allow a file to be searchable on the devhub, the file must provide metadata in the frontmatter